### PR TITLE
INTERLOK-3933 Use the new base filesystem zip from nexus.

### DIFF
--- a/src/main/resources/build.gradle
+++ b/src/main/resources/build.gradle
@@ -3,9 +3,9 @@ plugins {
 }
 
 ext {
-  interlokParentGradle = "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.10/v4/build.gradle"
+  interlokParentGradle  = project.findProperty("interlokParentGradle") ?: "https://raw.githubusercontent.com/adaptris/interlok-build-parent/1.8.10/v4/build.gradle"
 
-  latestBaseFilesystemUrl = "https://development.adaptris.net/installers/interlok/latest-stable/base-filesystem-no-ui.zip"
+  latestBaseFilesystemUrl = "https://nexus.adaptris.net/nexus/content/groups/interlok/com/adaptris/interlok-base-filesystem/1.0.0/interlok-base-filesystem-1.0.0-with-templates.zip"
   interlokBaseFilesystemUrl = project.findProperty("interlokBaseFilesystemUrl") ?: latestBaseFilesystemUrl
   
   interlokVersion = System.getProperty("interlokVersion") ?: (project.findProperty("interlokVersion") ?: "NEED interlokVersion PROPERTY")


### PR DESCRIPTION
## Motivation

We publish the base-filesystem zip artifact into nexus so we want to use it.

## Modification

- Use the new nexus url

## PR Checklist

- [x] been self-reviewed.

## Result

It should work the same as before, just using a different url

## Testing

Build the installer from this branch and test that it works fine and that the install adapter has the proper dir structure.
